### PR TITLE
remove extraneous .scannerwork directory

### DIFF
--- a/c_testcase/.scannerwork/report-task.txt
+++ b/c_testcase/.scannerwork/report-task.txt
@@ -1,6 +1,0 @@
-projectKey=c_benchmark
-serverUrl=http://10.10.3.102:4000
-serverVersion=7.6.0.21501
-dashboardUrl=http://10.10.3.102:4000/dashboard?id=c_benchmark
-ceTaskId=AWoHLXr994NBDN3necgz
-ceTaskUrl=http://10.10.3.102:4000/api/ce/task?id=AWoHLXr994NBDN3necgz


### PR DESCRIPTION
according to TX: this is for SonarQube.
I use this change to test the creation of a PR on the repo.